### PR TITLE
Add codeowners for translator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,5 @@
 /spectral/ @willosborne
 
 /visualizer/ @aidanm3341
+
+/translator/ @Budless @matthewgardner


### PR DESCRIPTION
Added @Budlee and @matthewgardner as the codeowners for the translator project.