### PR TITLE
#74 - Updating the api-gateway.json pattern to use prefixItems

### DIFF
--- a/calm/pattern/api-gateway.json
+++ b/calm/pattern/api-gateway.json
@@ -7,7 +7,7 @@
     "nodes": {
       "type": "array",
       "minItems": 3,
-      "items": [
+      "prefixItems": [
         {
           "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/core.json#/defs/node",
           "properties": {
@@ -105,7 +105,7 @@
     "relationships": {
       "type": "array",
       "minItems": 3,
-      "items": [
+      "prefixItems": [
         {
           "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/core.json#/defs/relationship",
           "properties": {


### PR DESCRIPTION
Updating the api-gateway.json pattern to use the prefixItems keyword instead of items as per JSON Schema 2020-12