### PR TITLE
#48 Remove mandatory interface on connects relationship

### DIFF
--- a/calm/draft/2024-04/meta/interface.json
+++ b/calm/draft/2024-04/meta/interface.json
@@ -21,7 +21,7 @@
       "interface": {
         "type": "string"
       },
-      "required": ["node", "interface"]
+      "required": ["node"]
     },
     "host-port-interface": {
       "ref": "#/defs/interface-type",


### PR DESCRIPTION
With https://github.com/finos-labs/architecture-as-code/pull/106 we have decided to make interfaces optional on a relationship for now. If it was mandatory that would remove the ability to use CALM as a logical tool and mean that it is only a physical modelling tool.

We may need to consider whether we have a convention to mark what type of diagram this is