### PR TITLE
Interface instantiation of explicit properties

### DIFF
--- a/calm/pattern/api-gateway.json
+++ b/calm/pattern/api-gateway.json
@@ -39,7 +39,7 @@
                   }
                 }
               ]
-             }
+            }
           },
           "required": [
             "well-known-endpoint",
@@ -84,8 +84,10 @@
               "prefixItems": [
                 {
                   "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-04/meta/interface.json#/defs/host-port-interface",
-                  "unique-id": {
-                    "const": "producer-ingress"
+                  "properties": {
+                    "unique-id": {
+                      "const": "producer-ingress"
+                    }
                   }
                 }
               ]
@@ -128,17 +130,16 @@
               "const": {
                 "connects": {
                   "source": {
-                      "node": "api-consumer"
+                    "node": "api-consumer"
                   },
                   "destination": {
-                      "node": "api-gateway",
-                      "interface": "api-gateway-ingress"
+                    "node": "api-gateway",
+                    "interface": "api-gateway-ingress"
                   }
                 }
               }
             },
-            "parties": {
-            },
+            "parties": {},
             "protocol": {
               "const": "HTTPS"
             },

--- a/cli/src/commands/generate/generate.spec.ts
+++ b/cli/src/commands/generate/generate.spec.ts
@@ -10,6 +10,7 @@ const {
     getPropertyValue,
     instantiateNodes,
     instantiateRelationships,
+    instantiateNodeInterfaces,
     initLogger
 } = exportedForTesting;
 
@@ -122,6 +123,119 @@ describe('instantiateNodes', () => {
         });
 
         expect(instantiateNodes(pattern))
+            .toEqual([
+                {
+                    'property-name': 'value here'
+                }
+            ]);
+    });
+
+    it('return instantiated node with interface', () => {
+        const pattern = {
+            properties: {
+                nodes: {
+                    type: 'array',
+                    prefixItems: [
+                        {
+                            properties: {
+                                'unique-id': {
+                                    'const': 'unique-id'
+                                },
+                                // interfaces should be inserted
+                                'interfaces': {
+                                    'prefixItems': [
+                                        {
+                                            properties: {
+                                                // should insert placeholder {{ INTERFACE_PROPERTY }}
+                                                'interface-property': {
+                                                    'type': 'string'
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                }
+
+            }
+
+        };
+
+        const expected = [
+            {
+                'unique-id': 'unique-id',
+                'interfaces': [
+                    {
+                        'interface-property': '{{ INTERFACE_PROPERTY }}'
+                    }
+                ]
+            }
+        ];
+
+        expect(instantiateNodes(pattern))
+            .toEqual(expected);
+
+    });
+});
+
+
+function getSampleNodeInterfaces(properties: any): any {
+    return {
+        prefixItems: [
+            {
+                properties: properties
+            }
+        ]
+    };
+}
+
+
+describe('instantiateNodeInterfaces', () => {
+    beforeEach(() => {
+        initLogger(false);
+    });
+
+    it('return instantiated node with array property', () => {
+        const pattern = getSampleNodeInterfaces({
+            'property-name': {
+                type: 'array'
+            }
+        });
+        expect(instantiateNodeInterfaces(pattern))
+            .toEqual(
+                [{
+                    'property-name': [
+                        '{{ PROPERTY_NAME }}'
+                    ]
+                }]
+            );
+    });
+
+    it('return instantiated node with string property', () => {
+        const pattern = getSampleNodeInterfaces({
+            'property-name': {
+                type: 'string'
+            }
+        });
+
+        expect(instantiateNodeInterfaces(pattern))
+            .toEqual([
+                {
+                    'property-name': '{{ PROPERTY_NAME }}'
+                }
+            ]);
+    });
+
+    it('return instantiated node with const property', () => {
+        const pattern = getSampleNodeInterfaces({
+            'property-name': {
+                const: 'value here'
+            }
+        });
+
+        expect(instantiateNodeInterfaces(pattern))
             .toEqual([
                 {
                     'property-name': 'value here'

--- a/cli/src/commands/generate/generate.ts
+++ b/cli/src/commands/generate/generate.ts
@@ -46,6 +46,30 @@ function getPropertyValue(keyName: string, detail: any) : any {
     }
 }
 
+function instantiateNodeInterfaces(detail: any): any[] {
+    const interfaces = [];
+    if (!('prefixItems' in detail)) {
+        console.error('No items in interfaces block.');
+        return [];
+    }
+
+    const interfaceDefs = detail.prefixItems;
+    for (const interfaceDef of interfaceDefs) {
+        if (!('properties' in interfaceDef)) {
+            continue;
+        }
+
+        const out = {};
+        for (const [key, detail] of Object.entries(interfaceDef['properties'])) {
+            out[key] = getPropertyValue(key, detail);
+        }
+
+        interfaces.push(out);
+    }
+
+    return interfaces;
+}
+
 function instantiateNodes(pattern: any): any {
     const nodes = pattern?.properties?.nodes?.prefixItems;
     if (!nodes) {
@@ -64,7 +88,13 @@ function instantiateNodes(pattern: any): any {
 
         const out = {};
         for (const [key, detail] of Object.entries(node['properties'])) {
-            out[key] = getPropertyValue(key, detail);
+            if (key === 'interfaces') {
+                const interfaces = instantiateNodeInterfaces(detail);
+                out['interfaces'] = interfaces;
+            }
+            else {
+                out[key] = getPropertyValue(key, detail);
+            }
         }
 
         outputNodes.push(out);
@@ -91,12 +121,7 @@ function instantiateRelationships(pattern: any): any {
 
         const out = {};
         for (const [key, detail] of Object.entries(relationship['properties'])) {
-            if (key === 'relationship-type') {
-                out[key] = getPropertyValue(key, detail);
-            }
-            else {
-                out[key] = getPropertyValue(key, detail);
-            }
+            out[key] = getPropertyValue(key, detail);
         }
 
         outputRelationships.push(out);
@@ -120,6 +145,7 @@ export const exportedForTesting = {
     getPropertyValue,
     instantiateNodes,
     instantiateRelationships,
+    instantiateNodeInterfaces,
     initLogger
 };
 


### PR DESCRIPTION
Instantiates interfaces when their properties are explicitly listed.
Does not traverse $refs or perform any lookups. 

#110 