### PR TITLE
Issue-98 - Unify spectral and JSON Schema validation output

### DIFF
--- a/cli/src/commands/validate/spectral.result.ts
+++ b/cli/src/commands/validate/spectral.result.ts
@@ -1,0 +1,12 @@
+import { ValidationOutput } from './validation.output';
+
+export class SpectralResult {
+    public errors: boolean;
+    public spectralIssues: ValidationOutput[];
+
+    constructor(errors: boolean, spectralIssues: ValidationOutput[]) {
+        this.errors = errors;
+        this.spectralIssues = spectralIssues;
+    }
+
+}

--- a/cli/src/commands/validate/validate.spec.ts
+++ b/cli/src/commands/validate/validate.spec.ts
@@ -197,7 +197,7 @@ const {
 
 describe('formatSpectralOutput', () => {
 
-    it('should convert the spectral output in the ValidationOutput format', () => {
+    it('should convert the spectral output to the ValidationOutput format', () => {
         const given: ISpectralDiagnostic[] = [
             {
                 code: 'no-empty-properties',
@@ -219,14 +219,14 @@ describe('formatSpectralOutput', () => {
             'no-empty-properties',
             'error',
             'Must not contain string properties set to the empty string or numerical properties set to zero',
-            'relationships.0.relationship-type.connects.destination.interface')]; 
+            '/relationships/0/relationship-type/connects/destination/interface')]; 
 
         const actual = formatSpectralOutput(given);
 
         expect(actual).toStrictEqual(expected);
     });
 
-    it('should convert the spectral output when path is an empty array in the ValidationOutput format', () => {
+    it('should convert the spectral output to the ValidationOutput format when path is an empty array', () => {
         const given: ISpectralDiagnostic[] = [
             {
                 code: 'no-empty-properties',
@@ -241,18 +241,24 @@ describe('formatSpectralOutput', () => {
             'no-empty-properties',
             'error',
             'Must not contain string properties set to the empty string or numerical properties set to zero',
-            '')]; 
+            '/')]; 
 
         const actual = formatSpectralOutput(given);
 
         expect(actual).toStrictEqual(expected);
     });
 
+    it('should return an empty array when spectral reports no issues', () => {
+        const given: ISpectralDiagnostic[] = [];
+        const expected : ValidationOutput[] = []; 
+        const actual = formatSpectralOutput(given);
+        expect(actual).toStrictEqual(expected);
+    });
+
 });
 
 describe('formatJsonSchemaOutput', () => {
-
-    it('should convert the json schema output in the ValidationOutput format', () => {
+    it('should convert the json schema output to the ValidationOutput format', () => {
         const given: ErrorObject[] = [
             {
                 'instancePath': '/nodes/0/interfaces/0/port',
@@ -280,7 +286,7 @@ describe('formatJsonSchemaOutput', () => {
         expect(actual).toStrictEqual(expected);
     });
 
-    it('should convert the json schema output when instancePath is empty in the ValidationOutput format', () => {
+    it('should convert the json schema output to the ValidationOutput format when instancePath is empty', () => {
         const given: ErrorObject[] = [
             {
                 'instancePath': '',
@@ -305,6 +311,13 @@ describe('formatJsonSchemaOutput', () => {
 
         const actual = formatJsonSchemaOutput(given);
 
+        expect(actual).toStrictEqual(expected);
+    });
+
+    it('should return an empty array when no JSON Schema issues have been reported', () => {
+        const given: ErrorObject[] = [];
+        const expected : ValidationOutput[] = [];
+        const actual = formatJsonSchemaOutput(given);
         expect(actual).toStrictEqual(expected);
     });
 

--- a/cli/src/commands/validate/validate.ts
+++ b/cli/src/commands/validate/validate.ts
@@ -58,7 +58,7 @@ export default async function validate(jsonSchemaInstantiationLocation: string, 
 
 function buildAjv2020(debug: boolean): Ajv2020 {
     if (debug){
-        return new Ajv2020({strict: "log", allErrors: true});
+        return new Ajv2020({strict: 'log', allErrors: true});
     }
     return new Ajv2020({strict: false, allErrors: true});
 }

--- a/cli/src/commands/validate/validate.ts
+++ b/cli/src/commands/validate/validate.ts
@@ -16,7 +16,7 @@ export default async function validate(jsonSchemaInstantiationLocation: string, 
     let errors = false;
     let validations: ValidationOutput[] = [];
     try {
-        const ajv = new Ajv2020({ strict: false , allErrors: true});
+        const ajv = buildAjv2020(debug);
 
         loadMetaSchemas(ajv, metaSchemaPath);
 
@@ -46,7 +46,7 @@ export default async function validate(jsonSchemaInstantiationLocation: string, 
         if(validations.length > 0){
             logger.info(`The following issues (not errors) have been found on the JSON Schema Instantiation ${prettifyJson(validations)}`);
         }else{
-            logger.info('The schema validation is valid');
+            logger.info('The JSON Schema instantiation is valid');
         }
         process.exit(0);
 
@@ -54,6 +54,13 @@ export default async function validate(jsonSchemaInstantiationLocation: string, 
         logger.error(`An error occured: ${error}`);
         process.exit(1);
     }
+}
+
+function buildAjv2020(debug: boolean): Ajv2020 {
+    if (debug){
+        return new Ajv2020({strict: "log", allErrors: true});
+    }
+    return new Ajv2020({strict: false, allErrors: true});
 }
 
 function loadMetaSchemas(ajv: Ajv2020, metaSchemaLocation: string) {
@@ -123,7 +130,7 @@ function formatSpectralOutput(spectralIssues: ISpectralDiagnostic[]): Validation
             issue.code,
             getSeverity(issue.severity), 
             issue.message, 
-            issue.path.join('.')
+            '/'+issue.path.join('/')
         );
         validationOutput.push(formattedIssue);
     });
@@ -142,7 +149,7 @@ function getSeverity(spectralSeverity: DiagnosticSeverity): string {
     case 3:
         return 'hint';
     default:
-        throw Error('uknown severity type returned by spectral');
+        throw Error('The spectralSeverity does not match the known values');
     }
 }
 

--- a/cli/src/commands/validate/validation.output.ts
+++ b/cli/src/commands/validate/validation.output.ts
@@ -1,0 +1,16 @@
+export class ValidationOutput {
+    public code: string | number;
+    public severity: string;
+    public message: string;
+    public path: string;
+    public schemaPath: string | undefined;
+
+
+    constructor(code: string | number, severity: string, message: string, path: string, schemaPath?: string){
+        this.code = code;
+        this.severity = severity;
+        this.message = message;
+        this.path = path;
+        this.schemaPath = schemaPath;
+    }
+} 


### PR DESCRIPTION
* Unify the output of spectral and Json Schema
* Enabling `strict: 'log'` option when the debug flag is provided

Example of the unified output:
```
info:    Loading meta schema(s) from ../calm/draft/2024-04/meta
info:    Loading pattern from : ../calm/pattern/api-gateway.json
info:    Loading pattern instantiation from : ../calm/samples/api-gateway-implementation.json
error:   The following issues have been found on the JSON Schema instantiation [
    {
        "code": "connects-relationship-references-existing-nodes",
        "severity": "error",
        "message": "'api-consumer' does not refer to the unique-id of an existing node.",
        "path": "/relationships/0/relationship-type/connects/source/node"
    },
    {
        "code": "json-schema",
        "severity": "error",
        "message": "must be integer",
        "path": "/nodes/0/interfaces/0/port",
        "schemaPath": "#/properties/port/type"
    },
    {
        "code": "json-schema",
        "severity": "error",
        "message": "must have required property 'unique-id'",
        "path": "/nodes/1",
        "schemaPath": "#/required"
    }
]
```