### PR TITLE
Fix spectral rules for interface restructure + fix node-interface in calm schema

### DIFF
--- a/calm/draft/2024-04/meta/interface.json
+++ b/calm/draft/2024-04/meta/interface.json
@@ -16,13 +16,15 @@
     },
     "node-interface": {
       "type": "object",
-      "node": {
-        "type": "string"
-      },
-      "interfaces": {
-        "type": "array",
-        "items": {
+      "properties": {
+        "node": {
           "type": "string"
+        },
+        "interfaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/calm/pattern/api-gateway.json
+++ b/calm/pattern/api-gateway.json
@@ -134,7 +134,9 @@
                   },
                   "destination": {
                     "node": "api-gateway",
-                    "interface": "api-gateway-ingress"
+                    "interfaces": [
+                      "api-gateway-ingress"
+                    ]
                   }
                 }
               }
@@ -157,12 +159,12 @@
             "relationship-type": {
               "const": {
                 "connects": {
-                    "source": {
-                        "node": "api-gateway"
-                    },
-                    "destination": { 
-                        "node": "idp"
-                    }
+                  "source": {
+                    "node": "api-gateway"
+                  },
+                  "destination": {
+                    "node": "idp"
+                  }
                 }
               }
             },
@@ -185,7 +187,9 @@
                   },
                   "destination": {
                     "node": "api-producer",
-                    "interface": "producer-ingress"
+                    "interfaces": [
+                      "producer-ingress"
+                    ]
                   }
                 }
               }

--- a/calm/samples/api-gateway-implementation.json
+++ b/calm/samples/api-gateway-implementation.json
@@ -48,7 +48,9 @@
         "connects": {
           "destination": {
             "node": "api-gateway",
-            "interface": "api-gateway-ingress"
+            "interfaces": [
+              "api-gateway-ingress"
+            ]
           },
           "source": {
             "node": "api-consumer"
@@ -75,7 +77,9 @@
         "connects": {
           "destination": {
             "node": "api-producer",
-            "interface": "producer-ingress"
+            "interfaces": [
+              "producer-ingress"
+            ]
           },
           "source": {
             "node": "api-gateway"

--- a/spectral/instantiation/validation-rules.yaml
+++ b/spectral/instantiation/validation-rules.yaml
@@ -70,11 +70,9 @@ rules:
     description: Referenced interfaces must be defined 
     severity: error 
     message: "{{error}}"
-    given: "$.relationships[*].relationship-type.connects.*" # both source and destination
+    given: "$.relationships[*].relationship-type.connects.*.interfaces[*]" # both source and destination
     then:
-      # node uses the interface structure so has a sub object
-      - field: interface
-        function: interface-id-exists
+      function: interface-id-exists
   
   composition-relationships-reference-existing-nodes:
     description: All nodes in a composition relationship must reference existing nodes

--- a/spectral/pattern/validation-rules.yaml
+++ b/spectral/pattern/validation-rules.yaml
@@ -80,11 +80,10 @@ rules:
     description: Referenced interfaces must be defined 
     severity: error 
     message: "{{error}}"
-    given: "$..relationship-type.const.connects.*" # both source and destination
+    given: "$..relationship-type.const.connects.*.interfaces[*]" # both source and destination
     then:
       # node uses the interface structure so has a sub object
-      - field: interface
-        function: interface-id-exists
+      function: interface-id-exists
 
   nodes-must-be-referenced:
     description: Nodes must be referenced by at least one relationship


### PR DESCRIPTION
Applies restructures to be reflected in Spectral rules. 

Also adds missing 'properties' block from node-interface. @jpgough-ms would appreciate a review on this one in particular.