### PR TITLE
Issue #95 - Strip  from patterns when validating with spectral

### DIFF
--- a/cli/src/commands/validate/validate.spec.ts
+++ b/cli/src/commands/validate/validate.spec.ts
@@ -343,7 +343,7 @@ describe('stripRefs', () => {
     const expectedString = '{"ref":123,"abc":{"ref":321}}';
 
     expect(exportedForTesting.stripRefs(objectWithRefs))
-    .toBe(expectedString);
+        .toBe(expectedString);
 });
 
 

--- a/cli/src/commands/validate/validate.spec.ts
+++ b/cli/src/commands/validate/validate.spec.ts
@@ -159,6 +159,21 @@ describe('validate', () => {
         fetchMock.restore();
     });
 
+    it('exits with error when the pattern does not pass all the spectral validations', async () => {
+
+        const apiGateway = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-with-no-relationships.json'), 'utf8');
+        fetchMock.mock('http://exist/api-gateway.json', apiGateway);
+
+        const apiGatewayInstantiation = readFileSync(path.resolve(__dirname, '../../../test_fixtures/api-gateway-implementation.json'), 'utf8');
+        fetchMock.mock('https://exist/api-gateway-implementation.json', apiGatewayInstantiation);
+
+        await expect(validate('https://exist/api-gateway-implementation.json', 'http://exist/api-gateway.json', metaSchemaLocation, debugDisabled))
+            .rejects
+            .toThrow();
+
+        fetchMock.restore();
+    });
+
     it('exits with error when the meta schema location is not a directory', async () => {
         await expect(validate('https://url/with/non/json/response', 'http://exist/api-gateway.json', 'test_fixtures/api-gateway.json', debugDisabled))
             .rejects
@@ -321,6 +336,14 @@ describe('formatJsonSchemaOutput', () => {
         expect(actual).toStrictEqual(expected);
     });
 
+});
+
+describe('stripRefs', () => {
+    const objectWithRefs = JSON.parse('{"$ref":123,"abc":{"$ref":321}}');
+    const expectedString = '{"ref":123,"abc":{"ref":321}}';
+
+    expect(exportedForTesting.stripRefs(objectWithRefs))
+    .toBe(expectedString);
 });
 
 

--- a/cli/src/commands/validate/validate.ts
+++ b/cli/src/commands/validate/validate.ts
@@ -92,7 +92,7 @@ async function runSpectralValidations(jsonSchemaInstantiation: string, jsonSchem
     const spectral = new Spectral();
 
     spectral.setRuleset(await getRuleset('../spectral/instantiation/validation-rules.yaml'));
-    var issues = await spectral.run(jsonSchemaInstantiation);
+    let issues = await spectral.run(jsonSchemaInstantiation);
     spectral.setRuleset(await getRuleset('../spectral/pattern/validation-rules.yaml'));
     issues = issues.concat(await spectral.run(jsonSchema));
 
@@ -185,7 +185,7 @@ function prettifyJson(json){
 }
 
 function stripRefs(obj: object) : string {
-    return JSON.stringify(obj).replaceAll("$ref", "ref");
+    return JSON.stringify(obj).replaceAll('$ref', 'ref');
 }
 
 export const exportedForTesting = {

--- a/cli/test_fixtures/api-gateway-with-no-relationships.json
+++ b/cli/test_fixtures/api-gateway-with-no-relationships.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/calm.json",
+  "$id": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/pattern/api-gateway",
+  "title": "API Gateway Pattern",
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 3,
+      "prefixItems": [
+        {
+          "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/core.json#/defs/node",
+          "properties": {
+            "ingress-host": {
+              "type": "string"
+            },
+            "ingress-port": {
+              "type": "integer"
+            },
+            "well-known-endpoint": {
+              "type": "string"
+            },
+            "description": {
+              "const": "The API Gateway used to verify authorization and access to downstream system"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "API Gateway"
+            },
+            "unique-id": {
+              "const": "api-gateway"
+            }
+          },
+          "required": [
+            "ingress-host",
+            "ingress-port",
+            "well-known-endpoint"
+          ]
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/core.json#/defs/node",
+          "properties": {
+            "description": {
+              "const": "The API Consumer making an authenticated and authorized request"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "Python Based API Consumer"
+            },
+            "unique-id": {
+              "const": "api-consumer"
+            }
+          }
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/core.json#/defs/node",
+          "properties": {
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "description": {
+              "const": "The API Producer serving content"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "Java Based API Producer"
+            },
+            "unique-id": {
+              "const": "api-producer"
+            }
+          },
+          "required": [
+            "host",
+            "port"
+          ]
+        },
+        {
+          "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-03/meta/core.json#/defs/node",
+          "properties": {
+            "description": {
+              "const": "The Identity Provider used to verify the bearer token"
+            },
+            "type": {
+              "const": "system"
+            },
+            "name": {
+              "const": "Identity Provider"
+            },
+            "unique-id": {
+              "const": "idp"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "required": [
+    "nodes",
+    "relationships"
+  ]
+}


### PR DESCRIPTION
This PR adds a function to strip `$ref` keys from pattern files and replace them with `ref` when performing Spectral validation.
This change also performs the Spectral validation and includes any errors in the output