### PR TITLE
Update node-cve-ignore-list.xml

### DIFF
--- a/.github/node-cve-ignore-list.xml
+++ b/.github/node-cve-ignore-list.xml
@@ -7,4 +7,11 @@
         <packageUrl regex="true">^pkg:npm/opener@.*$</packageUrl>
         <cpe>cpe:/a:opener_project:opener</cpe>
     </suppress>
+    <suppress>
+       <notes><![CDATA[
+       file name: json-pointer:0.6.2
+       ]]></notes>
+       <packageUrl regex="true">^pkg:npm/json\-pointer@.*$</packageUrl>
+       <cve>CVE-2022-4742</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
CVE check incorrectly flagging, we're using the version of json-pointer (0.6.2) which is recommended as the resolution - https://github.com/finos-labs/architecture-as-code/actions/runs/8891491142/job/24413564065.