### PR TITLE
Resolve top level references against the pattern itself and only instantiate required properties

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -65,6 +65,7 @@ Options:
   -p, --pattern <source>        Path to the pattern file to use. May be a file path or a URL.
   -o, --output <output>         Path location at which to output the generated file.
   -s, --schemaDirectory <path>  Path to a directory of schemas to be used when instantiating patterns.
+  -a, --instantiateAll          Instantiate ALL properties in the pattern, ignoring the 'required' field. (default: false)
   -v, --verbose                 Enable verbose logging. (default: false)
   -h, --help                    display help for command
 ```

--- a/cli/src/commands/generate/components/node.spec.ts
+++ b/cli/src/commands/generate/components/node.spec.ts
@@ -22,14 +22,15 @@ beforeEach(() => {
     mockSchemaDir = new SchemaDirectory('directory');
 });
 
-function getSamplePatternNode(properties: any): any {
+function getSamplePatternNode(properties: any, required: any = []): any {
     return {
         properties: {
             nodes: {
                 type: 'array',
                 prefixItems: [
                     {
-                        properties: properties
+                        properties: properties,
+                        required: required
                     }
                 ]
             }
@@ -39,13 +40,13 @@ function getSamplePatternNode(properties: any): any {
 
 
 describe('instantiateNodes', () => {
-    it('return instantiated node with array property', () => {
+    it('return instantiated required node with array property', () => {
         const pattern = getSamplePatternNode({
             'property-name': {
                 type: 'array'
             }
         });
-        expect(instantiateNodes(pattern, mockSchemaDir))
+        expect(instantiateNodes(pattern, mockSchemaDir, false, true))
             .toEqual(
                 [{
                     'property-name': [
@@ -62,7 +63,7 @@ describe('instantiateNodes', () => {
             }
         });
 
-        expect(instantiateNodes(pattern, mockSchemaDir))
+        expect(instantiateNodes(pattern, mockSchemaDir, false, true))
             .toEqual([
                 {
                     'property-name': '{{ PROPERTY_NAME }}'
@@ -77,7 +78,25 @@ describe('instantiateNodes', () => {
             }
         });
 
-        expect(instantiateNodes(pattern, mockSchemaDir))
+        expect(instantiateNodes(pattern, mockSchemaDir, false, true))
+            .toEqual([
+                {
+                    'property-name': 'value here'
+                }
+            ]);
+    });
+    
+    it('only instantiate required properties when instantiateAll set to false', () => {
+        const pattern = getSamplePatternNode({
+            'property-name': {
+                const: 'value here'
+            },
+            'other-property': {
+                const: 'should-be-ignored'
+            }
+        }, ['property-name']);
+
+        expect(instantiateNodes(pattern, mockSchemaDir, false, false))
             .toEqual([
                 {
                     'property-name': 'value here'
@@ -109,7 +128,7 @@ describe('instantiateNodes', () => {
             }
         });
 
-        expect(instantiateNodes(pattern, mockSchemaDir))
+        expect(instantiateNodes(pattern, mockSchemaDir, false, true))
             .toEqual([
                 {
                     'property-name': 'value here'
@@ -162,18 +181,19 @@ describe('instantiateNodes', () => {
             }
         ];
 
-        expect(instantiateNodes(pattern, mockSchemaDir))
+        expect(instantiateNodes(pattern, mockSchemaDir, false, false))
             .toEqual(expected);
 
     });
 });
 
 
-function getSampleNodeInterfaces(properties: any): any {
+function getSampleNodeInterfaces(properties: any, required: string[] = []): any {
     return {
         prefixItems: [
             {
-                properties: properties
+                properties: properties,
+                required: required
             }
         ]
     };
@@ -188,7 +208,7 @@ describe('instantiateNodeInterfaces', () => {
                 type: 'array'
             }
         });
-        expect(instantiateNodeInterfaces(pattern, mockSchemaDir))
+        expect(instantiateNodeInterfaces(pattern, mockSchemaDir, false, true))
             .toEqual(
                 [{
                     'property-name': [
@@ -205,7 +225,7 @@ describe('instantiateNodeInterfaces', () => {
             }
         });
 
-        expect(instantiateNodeInterfaces(pattern, mockSchemaDir))
+        expect(instantiateNodeInterfaces(pattern, mockSchemaDir, false, true))
             .toEqual([
                 {
                     'property-name': '{{ PROPERTY_NAME }}'
@@ -220,7 +240,25 @@ describe('instantiateNodeInterfaces', () => {
             }
         });
 
-        expect(instantiateNodeInterfaces(pattern, mockSchemaDir))
+        expect(instantiateNodeInterfaces(pattern, mockSchemaDir, false, true))
+            .toEqual([
+                {
+                    'property-name': 'value here'
+                }
+            ]);
+    });
+    
+    it('only instantiate required properties when instantiateAll set to false', () => {
+        const pattern = getSampleNodeInterfaces({
+            'property-name': {
+                const: 'value here'
+            },
+            'ignored-prop': {
+                const: 'value here'
+            }
+        }, ['property-name']);
+
+        expect(instantiateNodeInterfaces(pattern, mockSchemaDir, false, false))
             .toEqual([
                 {
                     'property-name': 'value here'
@@ -248,7 +286,7 @@ describe('instantiateNodeInterfaces', () => {
             }
         });
 
-        expect(instantiateNodeInterfaces(pattern, mockSchemaDir))
+        expect(instantiateNodeInterfaces(pattern, mockSchemaDir, false, true))
             .toEqual([
                 {
                     'property-name': 'value here'

--- a/cli/src/commands/generate/components/relationship.spec.ts
+++ b/cli/src/commands/generate/components/relationship.spec.ts
@@ -22,14 +22,15 @@ beforeEach(() => {
     mockSchemaDir = new SchemaDirectory('directory');
 });
 
-function getSamplePatternRelationship(properties: any): any {
+function getSamplePatternRelationship(properties: any, required: string[] = []): any {
     return {
         properties: {
             relationships: {
                 type: 'array',
                 prefixItems: [
                     {
-                        properties: properties
+                        properties: properties,
+                        required: required
                     }
                 ]
             }
@@ -46,7 +47,7 @@ describe('instantiateRelationships', () => {
             }
         });
 
-        expect(instantiateRelationships(pattern, mockSchemaDir))
+        expect(instantiateRelationships(pattern, mockSchemaDir, false, true))
             .toEqual(
                 [{
                     'property-name': [
@@ -63,7 +64,7 @@ describe('instantiateRelationships', () => {
             }
         });
 
-        expect(instantiateRelationships(pattern, mockSchemaDir))
+        expect(instantiateRelationships(pattern, mockSchemaDir, false, true))
             .toEqual([
                 {
                     'property-name': '{{ PROPERTY_NAME }}'
@@ -78,7 +79,25 @@ describe('instantiateRelationships', () => {
             }
         });
 
-        expect(instantiateRelationships(pattern, mockSchemaDir))
+        expect(instantiateRelationships(pattern, mockSchemaDir, false, true))
+            .toEqual([
+                {
+                    'property-name': 'value here'
+                }
+            ]);
+    });
+
+    it('only instantiate required properties when instantiateAll set to false', () => {
+        const pattern = getSamplePatternRelationship({
+            'property-name': {
+                const: 'value here'
+            },
+            'ignored-prop': {
+                const: 'value'
+            }
+        }, ['property-name']);
+
+        expect(instantiateRelationships(pattern, mockSchemaDir, false, false))
             .toEqual([
                 {
                     'property-name': 'value here'
@@ -110,7 +129,7 @@ describe('instantiateRelationships', () => {
             }
         });
 
-        expect(instantiateRelationships(pattern, mockSchemaDir))
+        expect(instantiateRelationships(pattern, mockSchemaDir, false, true))
             .toEqual([
                 {
                     'property-name': 'value here'

--- a/cli/src/commands/generate/generate.e2e.spec.ts
+++ b/cli/src/commands/generate/generate.e2e.spec.ts
@@ -1,7 +1,7 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
-import { runGenerate } from "./generate";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { runGenerate } from './generate';
 
 describe('generate spec e2e', () => {
     let tempDirectoryPath;
@@ -15,10 +15,10 @@ describe('generate spec e2e', () => {
     });
 
     it('instantiate file with self-reference', async () => {
-        const patternPath = 'test_fixtures/api-gateway-self-reference.json'
-        const schemaDirectoryPath = '../calm/draft/2024-04'
+        const patternPath = 'test_fixtures/api-gateway-self-reference.json';
+        const schemaDirectoryPath = '../calm/draft/2024-04';
         const outPath = path.join(tempDirectoryPath, 'output.json');
-        await runGenerate(patternPath, outPath, schemaDirectoryPath, true);
+        await runGenerate(patternPath, outPath, schemaDirectoryPath, true, false);
 
         expect(existsSync(outPath))
             .toBeTruthy();
@@ -31,7 +31,7 @@ describe('generate spec e2e', () => {
             .toHaveProperty('relationships');
 
 
-        expect(parsed['nodes'][0]).toHaveProperty('extra-prop')
-        expect(parsed['nodes'][0]['interfaces'][0]).toHaveProperty('extra-prop-interface')
+        expect(parsed['nodes'][0]).toHaveProperty('extra-prop');
+        expect(parsed['nodes'][0]['interfaces'][0]).toHaveProperty('extra-prop-interface');
     });
-})
+});

--- a/cli/src/commands/generate/generate.e2e.spec.ts
+++ b/cli/src/commands/generate/generate.e2e.spec.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { runGenerate } from "./generate";
+
+describe('generate spec e2e', () => {
+    let tempDirectoryPath;
+
+    beforeEach(() => {
+        tempDirectoryPath = mkdtempSync(path.join(tmpdir(), 'calm-test-'));
+    });
+
+    afterEach(() => {
+        rmSync(tempDirectoryPath, { recursive: true, force: true });
+    });
+
+    it('instantiate file with self-reference', async () => {
+        const patternPath = 'test_fixtures/api-gateway-self-reference.json'
+        const schemaDirectoryPath = '../calm/draft/2024-04'
+        const outPath = path.join(tempDirectoryPath, 'output.json');
+        await runGenerate(patternPath, outPath, schemaDirectoryPath, true);
+
+        expect(existsSync(outPath))
+            .toBeTruthy();
+
+        const spec = readFileSync(outPath, { encoding: 'utf-8' });
+        const parsed = JSON.parse(spec);
+        expect(parsed)
+            .toHaveProperty('nodes');
+        expect(parsed)
+            .toHaveProperty('relationships');
+
+
+        expect(parsed['nodes'][0]).toHaveProperty('extra-prop')
+        expect(parsed['nodes'][0]['interfaces'][0]).toHaveProperty('extra-prop-interface')
+    });
+})

--- a/cli/src/commands/generate/generate.spec.ts
+++ b/cli/src/commands/generate/generate.spec.ts
@@ -111,7 +111,7 @@ describe('runGenerate', () => {
 
     it('instantiates to given directory', () => {
         const outPath = path.join(tempDirectoryPath, 'output.json');
-        runGenerate(testPath, outPath, undefined, false);
+        runGenerate(testPath, outPath, undefined, false, false);
 
         expect(existsSync(outPath))
             .toBeTruthy();
@@ -119,7 +119,7 @@ describe('runGenerate', () => {
 
     it('instantiates to given directory with nested folders', () => {
         const outPath = path.join(tempDirectoryPath, 'output/test/output.json');
-        runGenerate(testPath, outPath, undefined, false);
+        runGenerate(testPath, outPath, undefined, false, false);
 
         expect(existsSync(outPath))
             .toBeTruthy();
@@ -127,7 +127,7 @@ describe('runGenerate', () => {
 
     it('instantiates to calm instantiation file', () => {
         const outPath = path.join(tempDirectoryPath, 'output.json');
-        runGenerate(testPath, outPath, undefined, false);
+        runGenerate(testPath, outPath, undefined, false, false);
 
         expect(existsSync(outPath))
             .toBeTruthy();

--- a/cli/src/commands/generate/generate.ts
+++ b/cli/src/commands/generate/generate.ts
@@ -53,6 +53,9 @@ export const exportedForTesting = {
 export function generate(patternPath: string, schemaDirectory: SchemaDirectory, debug: boolean): CALMInstantiation {
     logger = initLogger(debug);
     const pattern = loadFile(patternPath);
+
+    schemaDirectory.loadCurrentPatternAsSchema(pattern);
+
     const outputNodes = instantiateNodes(pattern, schemaDirectory, debug);
     const relationshipNodes = instantiateRelationships(pattern, schemaDirectory, debug);
     const additionalProperties = instantiateAdditionalTopLevelProperties(pattern, schemaDirectory);
@@ -79,6 +82,8 @@ export async function runGenerate(patternPath: string, outputPath: string, schem
     logger.debug('Generated instantiation: ' + output);
 
     const dirname = path.dirname(outputPath);
+
+    logger.debug('Writing output to ' + outputPath)
 
     mkdirp.sync(dirname);
     fs.writeFileSync(outputPath, output);

--- a/cli/src/commands/generate/generate.ts
+++ b/cli/src/commands/generate/generate.ts
@@ -50,14 +50,15 @@ export const exportedForTesting = {
     instantiateAdditionalTopLevelProperties
 };
 
-export function generate(patternPath: string, schemaDirectory: SchemaDirectory, debug: boolean): CALMInstantiation {
+export function generate(patternPath: string, schemaDirectory: SchemaDirectory, debug: boolean, instantiateAll: boolean): CALMInstantiation {
     logger = initLogger(debug);
     const pattern = loadFile(patternPath);
 
     schemaDirectory.loadCurrentPatternAsSchema(pattern);
 
-    const outputNodes = instantiateNodes(pattern, schemaDirectory, debug);
-    const relationshipNodes = instantiateRelationships(pattern, schemaDirectory, debug);
+    const outputNodes = instantiateNodes(pattern, schemaDirectory, debug, instantiateAll);
+    const relationshipNodes = instantiateRelationships(pattern, schemaDirectory, debug, instantiateAll);
+    // TODO
     const additionalProperties = instantiateAdditionalTopLevelProperties(pattern, schemaDirectory);
 
     const final = {
@@ -69,21 +70,21 @@ export function generate(patternPath: string, schemaDirectory: SchemaDirectory, 
     return final;
 }
 
-export async function runGenerate(patternPath: string, outputPath: string, schemaDirectoryPath: string, debug: boolean): Promise<void> {
+export async function runGenerate(patternPath: string, outputPath: string, schemaDirectoryPath: string, debug: boolean, instantiateAll: boolean): Promise<void> {
     const schemaDirectory = new SchemaDirectory(schemaDirectoryPath);
 
     if (schemaDirectoryPath) {
         await schemaDirectory.loadSchemas();
     }
     
-    const final = generate(patternPath, schemaDirectory, debug);
+    const final = generate(patternPath, schemaDirectory, debug, instantiateAll);
 
     const output = JSON.stringify(final, null, 2);
     logger.debug('Generated instantiation: ' + output);
 
     const dirname = path.dirname(outputPath);
 
-    logger.debug('Writing output to ' + outputPath)
+    logger.debug('Writing output to ' + outputPath);
 
     mkdirp.sync(dirname);
     fs.writeFileSync(outputPath, output);

--- a/cli/src/commands/generate/schema-directory.spec.ts
+++ b/cli/src/commands/generate/schema-directory.spec.ts
@@ -74,13 +74,13 @@ describe('SchemaDirectory', () => {
 
         await schemaDir.loadSchemas();
 
-        const selfRefPatternStr = await readFile("test_fixtures/api-gateway-self-reference.json", 'utf-8')
+        const selfRefPatternStr = await readFile('test_fixtures/api-gateway-self-reference.json', 'utf-8');
         const selfRefPattern = JSON.parse(selfRefPatternStr);
 
-        schemaDir.loadCurrentPatternAsSchema(selfRefPattern)
+        schemaDir.loadCurrentPatternAsSchema(selfRefPattern);
 
 
-        const nodeDef = schemaDir.getDefinition("#/defs/sample-node");
+        const nodeDef = schemaDir.getDefinition('#/defs/sample-node');
         expect(nodeDef.properties).toHaveProperty('extra-prop');
-    })
+    });
 });

--- a/cli/src/commands/generate/schema-directory.spec.ts
+++ b/cli/src/commands/generate/schema-directory.spec.ts
@@ -1,4 +1,5 @@
 import { SchemaDirectory } from './schema-directory';
+import { readFile } from 'node:fs/promises';
 
 jest.mock('../helper', () => {
     return {
@@ -67,4 +68,19 @@ describe('SchemaDirectory', () => {
         expect(interfaceDef.properties).toHaveProperty('top-level');
         expect(interfaceDef.properties).toHaveProperty('prop');
     });
+
+    it('look up self-definitions without schema ID at top level from the pattern itself', async () => {
+        const schemaDir = new SchemaDirectory('../calm/draft/2024-04');
+
+        await schemaDir.loadSchemas();
+
+        const selfRefPatternStr = await readFile("test_fixtures/api-gateway-self-reference.json", 'utf-8')
+        const selfRefPattern = JSON.parse(selfRefPatternStr);
+
+        schemaDir.loadCurrentPatternAsSchema(selfRefPattern)
+
+
+        const nodeDef = schemaDir.getDefinition("#/defs/sample-node");
+        expect(nodeDef.properties).toHaveProperty('extra-prop');
+    })
 });

--- a/cli/src/commands/generate/schema-directory.ts
+++ b/cli/src/commands/generate/schema-directory.ts
@@ -24,6 +24,11 @@ export class SchemaDirectory {
         this.logger = initLogger(debug);
     }
 
+    public loadCurrentPatternAsSchema(pattern: object) {
+        this.logger.debug("Loading current pattern as a schema.")
+        this.schemas.set('pattern', pattern);
+    }
+
     /**
      * Load the schemas from the configured directory path.
      */

--- a/cli/src/commands/generate/schema-directory.ts
+++ b/cli/src/commands/generate/schema-directory.ts
@@ -25,7 +25,7 @@ export class SchemaDirectory {
     }
 
     public loadCurrentPatternAsSchema(pattern: object) {
-        this.logger.debug("Loading current pattern as a schema.")
+        this.logger.debug('Loading current pattern as a schema.');
         this.schemas.set('pattern', pattern);
     }
 

--- a/cli/src/commands/generate/util.ts
+++ b/cli/src/commands/generate/util.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { Logger } from 'winston';
 
 /**
  * Recursively merge two schemas into a new object, without modifying either.
@@ -8,5 +9,19 @@ import _ from 'lodash';
  * @returns A new merged schema
  */
 export function mergeSchemas(s1: object, s2: object) {
-    return _.merge({}, s1, s2);
+    const s1Required = (s1 ?? {}) ['required'] ?? [];
+    const s2Required = (s2 ?? {}) ['required'] ?? [];
+    const newRequired = _.uniq([...s1Required, ...s2Required]);
+    const newSchema = _.merge({}, s1, s2);
+
+    newSchema['required'] = newRequired;
+    return newSchema;
+}
+
+export function logRequiredMessage(logger: Logger, required: string[], instantiateAll: boolean) {
+    if (instantiateAll) {
+        logger.debug('--instantiateAll was set, ignoring required list and instantiating all properties.');
+    } else {
+        logger.debug('Required properties: ' + required);
+    }
 }

--- a/cli/src/commands/visualize/visualize.ts
+++ b/cli/src/commands/visualize/visualize.ts
@@ -38,7 +38,7 @@ export async function visualizePattern(patternPath: string, output: string, debu
 
     // TODO add a path to load schemas and generate intelligently
     const schemaDir: SchemaDirectory = new SchemaDirectory(patternPath);
-    const instantiation = generate(patternPath, schemaDir, debug);
+    const instantiation = generate(patternPath, schemaDir, debug, false);
 
     logger.info('Generating an SVG from input');
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -33,8 +33,9 @@ program
     .requiredOption('-o, --output <output>', 'Path location at which to output the generated file.')
     .option('-s, --schemaDirectory <path>', 'Path to directory containing schemas to use in instantiation')
     .option('-v, --verbose', 'Enable verbose logging.', false)
+    .option('-a, --instantiateAll', 'Instantiate all properties, ignoring the "required" field.', false)
     .action(async (options) => {
-        await runGenerate(options.pattern, options.output, options.schemaDirectory, !!options.verbose);
+        await runGenerate(options.pattern, options.output, options.schemaDirectory, !!options.verbose, options.instantiateAll);
     });
 
 program

--- a/cli/test_fixtures/api-gateway-self-reference.json
+++ b/cli/test_fixtures/api-gateway-self-reference.json
@@ -1,0 +1,60 @@
+{
+  "$schema": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-04/meta/calm.json",
+  "$id": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/pattern/api-gateway",
+  "title": "API Gateway Pattern",
+  "type": "object",
+  "properties": {
+    "nodes": {
+      "type": "array",
+      "minItems": 3,
+      "prefixItems": [
+        {
+          "$ref": "#/defs/sample-node",
+          "properties": {
+            "unique-id": {
+              "const": "api-gateway"
+            }
+          }
+        }
+      ]
+    },
+    "relationships": {
+      "type": "array",
+      "prefixItems": [
+      ]
+    }
+  },
+  "required": [
+    "nodes",
+    "relationships"
+  ],
+  "defs": {
+    "sample-node": {
+      "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-04/meta/core.json#/defs/node",
+      "properties": {
+        "extra-prop": {
+          "type": "string"
+        },
+        "unique-id": {
+          "const": "api-gateway"
+        },
+        "interfaces": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "$ref": "#/defs/sample-interface"
+            }
+          ]
+        }
+      }
+    },
+    "sample-interface": {
+      "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-04/meta/interface.json#/defs/interface-type",
+      "properties": {
+        "extra-prop-interface": {
+          "const": "value"
+        }
+      }
+    }
+  }
+}

--- a/cli/test_fixtures/api-gateway-self-reference.json
+++ b/cli/test_fixtures/api-gateway-self-reference.json
@@ -46,7 +46,8 @@
             }
           ]
         }
-      }
+      },
+      "required": ["extra-prop"]
     },
     "sample-interface": {
       "$ref": "https://raw.githubusercontent.com/finos-labs/architecture-as-code/main/calm/draft/2024-04/meta/interface.json#/defs/interface-type",
@@ -54,7 +55,8 @@
         "extra-prop-interface": {
           "const": "value"
         }
-      }
+      },
+      "required": ["extra-prop-interface"]
     }
   }
 }


### PR DESCRIPTION
#139 

Also adds a property --instantiateAll or -a that ignores the 'required' fields and instantiates everything.