### PR TITLE
Visualizer fix

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -2,14 +2,14 @@ name: Build CLI
 
 on:
   pull_request:
-    branches: 
+    branches:
       - "main"
-    paths: 
+    paths:
       - "cli/**"
   push:
-    branches: 
+    branches:
       - "main"
-    paths: 
+    paths:
       - "cli/**"
 
 defaults:
@@ -28,4 +28,9 @@ jobs:
           node-version: v20
       - run: npm ci
       - run: npm run test
-      - run: npm run lint 
+      - run: npm run lint
+      - run: npm run build
+      # Try running each command
+      - run: npx calm validate -p ../calm/pattern/api-gateway.json -i ../calm/samples/api-gateway-implementation.json
+      - run: npx calm generate -p ../calm/pattern/api-gateway.json -s ../calm/draft/2024-04/meta
+      - run: npx calm visualize -p ../calm/pattern/api-gateway.json

--- a/cli/src/commands/generate/components/property.ts
+++ b/cli/src/commands/generate/components/property.ts
@@ -1,5 +1,3 @@
-/* eslint-disable  @typescript-eslint/no-explicit-any */
-
 export function getStringPlaceholder(name: string): string {
     return '{{ ' + name.toUpperCase().replaceAll('-', '_') + ' }}';
 }
@@ -8,16 +6,22 @@ export function getRefPlaceholder(name: string): string {
     return '{{ REF_' + name.toUpperCase().replaceAll('-', '_') + ' }}';
 }
 
-export function getPropertyValue(keyName: string, detail: any): any {
+interface Detail {
+    const?: string | object,
+    type?: 'string' | 'integer' | 'number' | 'array',
+    $ref?: string
+}
+
+export function getPropertyValue(keyName: string, detail: Detail): string | string[] | number | object {
     // TODO follow refs here
     // should be able to instantiate not just a simple enum type but also a whole sub-object
     // if both const and type are defined, prefer const
-    if ('const' in detail) {
-        return detail['const'];
+    if (detail.const) {
+        return detail.const;
     }
 
-    if ('type' in detail) {
-        const propertyType = detail['type'];
+    if (detail.type) {
+        const propertyType = detail.type;
 
         if (propertyType === 'string') {
             return getStringPlaceholder(keyName);
@@ -32,7 +36,7 @@ export function getPropertyValue(keyName: string, detail: any): any {
         }
     }
 
-    if ('$ref' in detail) {
+    if (detail.$ref) {
         return getRefPlaceholder(keyName);
     }
 }

--- a/cli/src/commands/visualize/calmToDot.ts
+++ b/cli/src/commands/visualize/calmToDot.ts
@@ -16,6 +16,7 @@ export default function(calm: CALMInstantiation, debug: boolean = false): string
 
     calm.nodes.forEach(node => {
         logger.debug(`Creating a node with ID [${node['unique-id']}]`);
+        logger.debug(`Using the following node [${JSON.stringify(node)}]`);
         addNode(G, node);
     });
     calm.relationships.forEach(relationship => {
@@ -50,6 +51,7 @@ function capitalizeFirstLetter(s: string): string {
 }
 
 function addRelationship(g: Digraph, relationship: CALMRelationship): void {
+    logger.debug(`Using the following relationship [${JSON.stringify(relationship)}]`);
     if ('connects' in relationship['relationship-type']) {
         addConnectsRelationship(g, relationship as CALMConnectsRelationship);
     } else if ('interacts' in relationship['relationship-type']) {

--- a/cli/src/commands/visualize/visualize.spec.ts
+++ b/cli/src/commands/visualize/visualize.spec.ts
@@ -28,86 +28,108 @@ jest.mock('../helper.js', () => {
     };
 });
 
-describe('visualize instantiation', () => {
+describe('visualizer', () => {
+    let mockExit;
+
     beforeEach(() => {
-        (readFileSync as jest.Mock).mockReturnValue(`
-        {
-            "nodes": [],
-            "relationships": []
-        }
-        `);
-    });
-
-
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    it('reads from the given input file', async () => {
-        jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
-
-        await visualizeInstantiation('./input.json', './output.svg', false);
-        expect(readFileSync).toHaveBeenCalledWith('./input.json', 'utf-8');
-    });
-
-    it('writes to the given output file', async () => {
-        jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
-
-        await visualizeInstantiation('./input.json', './output.svg', false);
-        expect(writeFileSync).toHaveBeenCalledWith('./output.svg', '<svg></svg>');
-    });
-
-    it('doesnt write if an error is thrown', async () => {
-        jest.spyOn(graphviz, 'renderGraphFromSource').mockRejectedValue(new Error());
-
-        await visualizeInstantiation('./input.json', './output.svg', false);
-        expect(writeFileSync).not.toHaveBeenCalled();
-    });
-});
-
-describe('visualize pattern', () => {
-    beforeEach(() => {
-        (readFileSync as jest.Mock).mockReturnValue(`
-        {
-            "properties": {
-                "nodes": {
-                    "prefixItems": []
-                },
-                "relationships": {
-                    "prefixItems": []
+        mockExit = jest.spyOn(process, 'exit')
+            .mockImplementation((code) => {
+                if (code != 0) {
+                    throw new Error();
                 }
-            },
-            "required": [
-                "nodes",
-                "relationships"
-            ]
-        }
-        `);
+                return undefined as never;
+            });
     });
 
+    describe('visualize instantiation', () => {
 
-    afterEach(() => {
-        jest.resetAllMocks();
+        beforeEach(() => {
+            (readFileSync as jest.Mock).mockReturnValue(`
+            {
+                "nodes": [],
+                "relationships": []
+            }
+            `);
+        });
+
+
+        afterEach(() => {
+            jest.resetAllMocks();
+            mockExit.mockRestore();
+        });
+
+        it('reads from the given input file', async () => {
+            jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
+
+            await visualizeInstantiation('./input.json', './output.svg', false);
+            expect(readFileSync).toHaveBeenCalledWith('./input.json', 'utf-8');
+        });
+
+        it('writes to the given output file', async () => {
+            jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
+
+            await visualizeInstantiation('./input.json', './output.svg', false);
+            expect(writeFileSync).toHaveBeenCalledWith('./output.svg', '<svg></svg>');
+        });
+
+        it('doesnt write if an error is thrown', async () => {
+            jest.spyOn(graphviz, 'renderGraphFromSource').mockRejectedValue(new Error());
+
+            await expect(visualizeInstantiation('./input.json', './output.svg', false))
+                .rejects
+                .toThrow();
+            expect(writeFileSync).not.toHaveBeenCalled();
+            expect(mockExit).toHaveBeenCalledWith(1);
+        });
     });
 
-    it('reads from the given input file', async () => {
-        jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
+    describe('visualize pattern', () => {
+        beforeEach(() => {
+            (readFileSync as jest.Mock).mockReturnValue(`
+            {
+                "properties": {
+                    "nodes": {
+                        "prefixItems": []
+                    },
+                    "relationships": {
+                        "prefixItems": []
+                    }
+                },
+                "required": [
+                    "nodes",
+                    "relationships"
+                ]
+            }
+            `);
+        });
 
-        await visualizePattern('./input.json', './output.svg', false);
-        expect(readFileSync).toHaveBeenCalledWith('./input.json', 'utf-8');
-    });
 
-    it('writes to the given output file', async () => {
-        jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
 
-        await visualizePattern('./input.json', './output.svg', false);
-        expect(writeFileSync).toHaveBeenCalledWith('./output.svg', '<svg></svg>');
-    });
+        it('reads from the given input file', async () => {
+            jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
 
-    it('doesnt write if an error is thrown', async () => {
-        jest.spyOn(graphviz, 'renderGraphFromSource').mockRejectedValue(new Error());
+            await visualizePattern('./input.json', './output.svg', false);
+            expect(readFileSync).toHaveBeenCalledWith('./input.json', 'utf-8');
+        });
 
-        await visualizePattern('./input.json', './output.svg', false);
-        expect(writeFileSync).not.toHaveBeenCalled();
+        it('writes to the given output file', async () => {
+            jest.spyOn(graphviz, 'renderGraphFromSource').mockResolvedValue('<svg></svg>');
+
+            await visualizePattern('./input.json', './output.svg', false);
+            expect(writeFileSync).toHaveBeenCalledWith('./output.svg', '<svg></svg>');
+        });
+
+        it('doesnt write if an error is thrown', async () => {
+            jest.spyOn(graphviz, 'renderGraphFromSource').mockRejectedValue(new Error());
+
+            await expect(visualizePattern('./input.json', './output.svg', false))
+                .rejects
+                .toThrow();
+            expect(writeFileSync).not.toHaveBeenCalled();
+            expect(mockExit).toHaveBeenCalledWith(1);
+        });
     });
 });

--- a/cli/src/commands/visualize/visualize.ts
+++ b/cli/src/commands/visualize/visualize.ts
@@ -26,10 +26,9 @@ export async function visualizeInstantiation(instantiationPath: string, output: 
 
         logger.info(`Outputting file at [${output}]`);
         fs.writeFileSync(output, svg);
-        return;
     } catch (err) {
         logger.error(err);
-        return;
+        process.exit(1);
     }
 }
 
@@ -52,9 +51,8 @@ export async function visualizePattern(patternPath: string, output: string, debu
 
         logger.info(`Outputting file at [${output}]`);
         fs.writeFileSync(output, svg);
-        return;
     } catch (err) {
         logger.error(err);
-        return;
+        process.exit(1);
     }
 }

--- a/cli/src/commands/visualize/visualize.ts
+++ b/cli/src/commands/visualize/visualize.ts
@@ -37,7 +37,7 @@ export async function visualizePattern(patternPath: string, output: string, debu
 
     // TODO add a path to load schemas and generate intelligently
     const schemaDir: SchemaDirectory = new SchemaDirectory(patternPath);
-    const instantiation = generate(patternPath, schemaDir, debug, false);
+    const instantiation = generate(patternPath, schemaDir, debug, true);
 
     logger.info('Generating an SVG from input');
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -30,7 +30,7 @@ program
     .command('generate')
     .description('Generate an instantiation from a CALM pattern file.')
     .requiredOption('-p, --pattern <source>', 'Path to the pattern file to use. May be a file path or a URL.')
-    .requiredOption('-o, --output <output>', 'Path location at which to output the generated file.')
+    .requiredOption('-o, --output <output>', 'Path location at which to output the generated file.', 'instantiation.json')
     .option('-s, --schemaDirectory <path>', 'Path to directory containing schemas to use in instantiation')
     .option('-v, --verbose', 'Enable verbose logging.', false)
     .option('-a, --instantiateAll', 'Instantiate all properties, ignoring the "required" field.', false)

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -42,7 +42,7 @@ program
     .command('validate')
     .requiredOption('-p, --pattern <pattern>', 'Path to the pattern file to use. May be a file path or a URL.')
     .requiredOption('-i, --instantiation <instantiation>', 'Path to the pattern instantiation file to use. May be a file path or a URL.')
-    .option('-m, --metaSchemasLocation <metaSchemaLocation>', 'The location of the directory of the meta schemas to be loaded', '../calm/draft/2024-03/meta')
+    .option('-m, --metaSchemasLocation <metaSchemaLocation>', 'The location of the directory of the meta schemas to be loaded', '../calm/draft/2024-04/meta')
     .addOption(
         new Option('-f, --format <format>', 'The format of the output')
             .choices(['json', 'junit'])


### PR DESCRIPTION
There are a few small changes I've made here:
- I've updated the GH build action to include running the CLI as part of the tests, this will hopefully help us catch if changes introduce any failures
- To facilitate the previous point, I added proper exit status codes to the visualizer
- The validator defaulted to using a previous meta schema which wasn't compatible with the current sample patterns, I updated that to the latest version
- A recent change which only instantiates required fields broke the visualizer, I've updated it to instantiate all fields when rendering a pattern
- THE PLAGUE OF '**ANY**' STRIKES! A recent change meant that a field which we were assuming was an object (via the use of the 'in' operator) was possibly now just a `string`, but because we had typed that field as `any`, we didn't catch that bug from our incorrect assumption. I've added some basic types to that file to make a start - but there is still a lot of work to do with the types to improve this further.